### PR TITLE
:pushpin: Avoid install backports on python < 3.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ async-timeout==3.0.1
 attrs==20.3.0
 autobahn==21.3.1
 Automat==20.2.0
-backports.zoneinfo==0.2.1
+backports.zoneinfo==0.2.1;python_version<"3.9"
 CacheControl==0.12.6
 certifi==2019.11.28
 cffi==1.14.5


### PR DESCRIPTION
The backports.zoneinfo module is a drop-in replacement for the Python 3.9 standard library module zoneinfo.
It provides the same API and functionality, but uses the tzdata package to provide the time zone data instead of the OS.

https://stackoverflow.com/questions/71712258/error-could-not-build-wheels-for-backports-zoneinfo-which-is-required-to-insta